### PR TITLE
where's the quadratic

### DIFF
--- a/src/org/usfirst/frc1727/REX/commands/DriveCommand.java
+++ b/src/org/usfirst/frc1727/REX/commands/DriveCommand.java
@@ -21,7 +21,9 @@ public class DriveCommand extends Command {
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
 	    if (Robot.oi.getDriver().getRawAxis(2) > 0.25 || Robot.oi.getDriver().getRawAxis(3) > 0.25)
-	    	// 0.77459666924 = sqrt(6)
+	    	// 0.77459666924 = sqrt(0.6)
+		    //also where's the fucking quadratic drive
+		    //i see no square term
 	    	Robot.driveSubsystem.getRobotDrive().tankDrive(Robot.oi.getDriver().getRawAxis(5) * 0.77459666924, Robot.oi.getDriver().getRawAxis(1) * 0.77459666924, true);
     	else
 	    	Robot.driveSubsystem.getRobotDrive().tankDrive(Robot.oi.getDriver().getRawAxis(5), Robot.oi.getDriver().getRawAxis(1), true);


### PR DESCRIPTION
fucking root(0.6) for absolutely no reason, there's no square (unless it's hidden in the definition of tankDrive()